### PR TITLE
Ticket pool visualization eventlock

### DIFF
--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -170,25 +170,37 @@ func MakeTxInsertStatement(checked bool) string {
 	return insertTxRow
 }
 
-// MakeRetrieveTicketStatement fetches live and
-// immature tickets in the current ticket pool
-func MakeRetrieveTicketsStatement(hashes []string, graphType int, info ...int64) string {
-	var liveBlocks int64
-	if len(info) > 0 {
-		liveBlocks = info[0] - 256
-	}
+// TicketGrouping indicates if tickets retrieved via
+// MakeRetrieveTicketTimesStatement should be grouped by date/time or by price.
+type TicketGrouping int
 
-	var strHashes = `VALUES ('` + strings.Join(hashes, `'), ('`) + `')`
-	switch graphType {
-	case 1:
+const (
+	TicketsByDateTime TicketGrouping = iota
+	TicketsByPrice
+)
+
+// MakeRetrieveTicketStatement creates the statement to fetch data on the
+// provided ticket IDs grouped by either purchase time or purchase price. The
+// sinceBlock is used to specify at which height tickets should be considered
+// mature.
+func MakeRetrieveTicketTimesStatement(hashes []string, ticketGrouping TicketGrouping,
+	sinceBlock int64) string {
+	strHashes := `VALUES ('` + strings.Join(hashes, `'), ('`) + `')`
+	switch ticketGrouping {
+	case TicketsByDateTime:
 		return fmt.Sprintf(retrieveTicketsByPurchaseDate,
-			liveBlocks, liveBlocks, strHashes)
-	case 2:
+			sinceBlock, sinceBlock, strHashes)
+	case TicketsByPrice:
 		return fmt.Sprintf(retrieveTicketsByPrice,
-			liveBlocks, liveBlocks, strHashes)
-	case 3:
-		return fmt.Sprintf(retrieveTicketsByType, strHashes)
+			sinceBlock, sinceBlock, strHashes)
 	default:
 		return ""
 	}
+}
+
+// MakeRetrieveTicketTypeCountsStatement fetches the count of solo, pooled, or
+// otherwise split ticket purchases given the provided ticket IDs.
+func MakeRetrieveTicketTypeCountsStatement(hashes []string) string {
+	strHashes := `VALUES ('` + strings.Join(hashes, `'), ('`) + `')`
+	return fmt.Sprintf(retrieveTicketsByType, strHashes)
 }

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -498,7 +498,7 @@ func (pgb *ChainDB) TicketPoolByDateAndInterval(interval string) ([]string, *dbt
 	case "all":
 		sec = 1
 	default:
-		return []string{}, nil, 0, fmt.Errorf(`The interval provided "%s" is unknown`, interval)
+		return []string{}, nil, 0, fmt.Errorf(`unknown interval "%s"`, interval)
 	}
 
 	// All ticket IDs for live and immature tickets

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -426,23 +426,26 @@ func (pgb *ChainDB) AddressHistoryAll(address string, N, offset int64) ([]*dbtyp
 	return pgb.AddressHistory(address, N, offset, dbtypes.AddrTxnAll)
 }
 
-// getTicketPoolHashes returns the tickets hashes and the best block needed to
-// plot ticketpool charts.
+// getTicketPoolHashes returns the union of live (ticket pool) and immature
+// ticket hashes, and the best block of the stake database.
 func (pgb *ChainDB) getTicketPoolHashes() ([]string, int64, error) {
-	var bestBlock = int64(pgb.GetHeight())
-	var tickets, err = pgb.stakeDB.PoolAtHeight(bestBlock)
+	// Live tickets at best block
+	bestBlock := int64(pgb.stakeDB.Height())
+	tickets, err := pgb.stakeDB.PoolAtHeight(bestBlock)
 	if err != nil {
 		return nil, bestBlock, err
 	}
 
-	var ticketsHashes = make([]string, len(tickets))
-	for i, hash := range tickets {
-		ticketsHashes[i] = hash.String()
-	}
-
+	// Immature tickets
 	immatureHashes, err := retrieveImmatureTickets(pgb.db, bestBlock)
 	if err != nil {
 		return nil, bestBlock, err
+	}
+
+	// Concatenate live and immature ticket IDs
+	ticketsHashes := make([]string, len(tickets), len(tickets)+len(immatureHashes))
+	for i := range tickets {
+		ticketsHashes[i] = tickets[i].String()
 	}
 
 	ticketsHashes = append(ticketsHashes, immatureHashes...)
@@ -450,22 +453,28 @@ func (pgb *ChainDB) getTicketPoolHashes() ([]string, int64, error) {
 	return ticketsHashes, bestBlock, nil
 }
 
-// TicketPoolVisualization fetches the ticketpool data. The data is needed to
-// populate the ticketpool graphs.
-func (pgb *ChainDB) TicketPoolVisualization(bars string) ([]*dbtypes.PoolTicketsData, *dbtypes.PoolTicketsData, error) {
-	var allTickets = make([]*dbtypes.PoolTicketsData, 3)
-	var ticketsHashes, tickets, bestBlock, err = pgb.TicketPoolByDateAndInterval(bars)
+// TicketPoolVisualization fetches the following ticketpool data: tickets
+// grouped on the specified interval, tickets grouped by price, and ticket
+// counts by ticket type (solo, pool, other split). The interval may be one of:
+// "mo", "wk", "day", or "all". The data is needed to populate the ticketpool
+// graphs. The data grouped by time and price are returned in a slice.
+func (pgb *ChainDB) TicketPoolVisualization(interval string) ([]*dbtypes.PoolTicketsData, *dbtypes.PoolTicketsData, error) {
+	// Tickets grouped by time interval
+	ticketsHashes, ticketsByTime, bestBlock, err := pgb.TicketPoolByDateAndInterval(interval)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	allTickets[0] = tickets
-
-	allTickets[1], err = retrieveTicketByPrice(pgb.db, bestBlock, ticketsHashes)
+	// Tickets grouped by price
+	ticketsByPrice, err := retrieveTicketByPrice(pgb.db, bestBlock, ticketsHashes)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	// Return time- and price-grouped data in a slice
+	allTickets := []*dbtypes.PoolTicketsData{ticketsByTime, ticketsByPrice}
+
+	// Tickets grouped by type (solo, pool, other split)
 	grpTickets, err := retrieveTickesGroupedByType(pgb.db, ticketsHashes)
 	if err != nil {
 		return nil, nil, err
@@ -475,28 +484,31 @@ func (pgb *ChainDB) TicketPoolVisualization(bars string) ([]*dbtypes.PoolTickets
 }
 
 // TicketPoolByDateAndInterval fetches the tickets ordered by the purchase date
-// interval provided.
-func (pgb *ChainDB) TicketPoolByDateAndInterval(val string) ([]string, *dbtypes.PoolTicketsData, int64, error) {
+// interval provided, the corresponding PoolTicketsData, the height of the best
+// block in the stake database, and an error value.
+func (pgb *ChainDB) TicketPoolByDateAndInterval(interval string) ([]string, *dbtypes.PoolTicketsData, int64, error) {
 	var sec int64
-	switch val {
-	case "1m":
-		sec = 2629746
-	case "1wk":
-		sec = 604800
-	case "1d":
-		sec = 86400
+	switch interval {
+	case "mo":
+		sec = int64(float64(time.Hour) * 24 * 30.436875) // Gregorian month
+	case "wk":
+		sec = int64(time.Hour) * 24 * 7
+	case "day":
+		sec = int64(time.Hour) * 24
 	case "all":
 		sec = 1
 	default:
-		return []string{}, nil, 0, fmt.Errorf("The interval provided '%s' is unknown", val)
+		return []string{}, nil, 0, fmt.Errorf(`The interval provided "%s" is unknown`, interval)
 	}
 
-	var ticketsHashes, bestBlock, err = pgb.getTicketPoolHashes()
+	// All ticket IDs for live and immature tickets
+	ticketsHashes, bestBlock, err := pgb.getTicketPoolHashes()
 	if err != nil {
 		return ticketsHashes, nil, 0, err
 	}
 
-	t, err := retrieveTicketsByDate(pgb.db, bestBlock, ticketsHashes, sec)
+	maturityBlock := bestBlock - int64(pgb.chainParams.TicketMaturity)
+	t, err := retrieveTicketsByDate(pgb.db, maturityBlock, ticketsHashes, sec)
 	return ticketsHashes, t, bestBlock, err
 }
 

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1241,14 +1241,16 @@ func retrieveImmatureTickets(db *sql.DB, bestBlock int64) (hashes []string, err 
 
 // retrieveTicketsByDate fetches the tickets in the current ticketpool by the
 // purchase date.
-func retrieveTicketsByDate(db *sql.DB, bestBlock int64,
-	hashes []string, groupBy int64) (*dbtypes.PoolTicketsData, error) {
-	var rows, err = db.Query(internal.MakeRetrieveTicketsStatement(hashes, 1, bestBlock), groupBy)
+func retrieveTicketsByDate(db *sql.DB, bestBlock int64, hashes []string,
+	groupBy int64) (*dbtypes.PoolTicketsData, error) {
+	// Create the query statement and retrieve rows
+	rows, err := db.Query(internal.MakeRetrieveTicketTimesStatement(hashes,
+		internal.TicketsByDateTime, bestBlock), groupBy)
 	if err != nil {
 		return nil, err
 	}
 
-	var tickets = new(dbtypes.PoolTicketsData)
+	tickets := new(dbtypes.PoolTicketsData)
 	for rows.Next() {
 		var immature, live, timestamp uint64
 		var price, total float64
@@ -1269,12 +1271,14 @@ func retrieveTicketsByDate(db *sql.DB, bestBlock int64,
 // retrieveTicketByPrice fetches the tickets in the current ticketpool by the
 // purchase price.
 func retrieveTicketByPrice(db *sql.DB, bestBlock int64, hashes []string) (*dbtypes.PoolTicketsData, error) {
-	var tickets = new(dbtypes.PoolTicketsData)
-	var rows, err = db.Query(internal.MakeRetrieveTicketsStatement(hashes, 2, bestBlock))
+	// Create the query statement and retrieve rows
+	rows, err := db.Query(internal.MakeRetrieveTicketTimesStatement(hashes,
+		internal.TicketsByPrice, bestBlock))
 	if err != nil {
 		return nil, err
 	}
 
+	tickets := new(dbtypes.PoolTicketsData)
 	for rows.Next() {
 		var immature, live uint64
 		var price float64
@@ -1291,10 +1295,10 @@ func retrieveTicketByPrice(db *sql.DB, bestBlock int64, hashes []string) (*dbtyp
 }
 
 // retrieveTickesGroupedByType the count of tickets in the current ticketpool
-// grouped by their outputs.
+// grouped by ticket type (inferred by their output counts).
 func retrieveTickesGroupedByType(db *sql.DB, hashes []string) (*dbtypes.PoolTicketsData, error) {
 	var entry dbtypes.PoolTicketsData
-	err := db.QueryRow(internal.MakeRetrieveTicketsStatement(hashes, 3)).Scan(
+	err := db.QueryRow(internal.MakeRetrieveTicketTypeCountsStatement(hashes)).Scan(
 		&entry.Solo, &entry.Pooled, &entry.TxSplit,
 	)
 	if err != nil {

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -71,7 +71,7 @@ type explorerDataSource interface {
 	AgendaVotes(agendaID string, chartType int) (*dbtypes.AgendaVoteChoices, error)
 	GetPgChartsData() (map[string]*dbtypes.ChartsData, error)
 	GetTicketsPriceByHeight() (*dbtypes.ChartsData, error)
-	TicketPoolVisualization(bars string) ([]*dbtypes.PoolTicketsData, *dbtypes.PoolTicketsData, error)
+	TicketPoolVisualization(interval string) ([]*dbtypes.PoolTicketsData, *dbtypes.PoolTicketsData, error)
 }
 
 // cacheChartsData holds the prepopulated data that is used to draw the charts

--- a/explorer/websockethandlers.go
+++ b/explorer/websockethandlers.go
@@ -117,8 +117,13 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 
 					cData, gData, err := exp.explorerSource.TicketPoolVisualization(msg.Message)
 					if err != nil {
+						if strings.HasPrefix(err.Error(), "unknown interval") {
+							log.Debugf("Invalid ticket pool interval provided via getticketpooldata: %s", msg.Message)
+							webData.Message = "Error: " + err.Error()
+							break
+						}
 						log.Errorf("TicketPoolVisualization error: %v", err)
-						webData.Message = "Error: Failed to successfully fetch ticketpool data"
+						webData.Message = "Error: Failed to fetch ticketpool data"
 						break
 					}
 

--- a/public/js/controllers/ticketpool.js
+++ b/public/js/controllers/ticketpool.js
@@ -109,9 +109,9 @@ function barchartPlotter(e) {
 
     function getWindow(val){
         switch (val){
-            case "1d": return [(ms - 8.64E+07) - 1000, ms]
-            case "1wk": return [(ms - 6.048e+8) - 1000, ms]
-            case "1m": return [(ms - 2.628e+9) - 1000, ms]
+            case "day": return [(ms - 8.64E+07) - 1000, ms]
+            case "wk": return [(ms - 6.048e+8) - 1000, ms]
+            case "mo": return [(ms - 2.628e+9) - 1000, ms]
             default: return [origDate, ms]
         }
     }


### PR DESCRIPTION
- [x] Add `TicketGrouping` type and an enumeration to improve readability.
- [x] Rename 1d/1wk/1m to day/wk/mo. The "1" looks too much like an "l".
- [x] Use `chaincfg.TicketMaturity` for computing ticket maturity block.
- [x] Handling of `getticketpooldata` websocket messages: If interval is not recognized, the user has provided invalid input. Not an error.
- [ ] Address repeated requests for same ticket pool data. (refactor tpEvent stuff)